### PR TITLE
Fixed wrong behavior of FirstOrEmpty

### DIFF
--- a/src/DotNext/Collections/Generic/Sequence.cs
+++ b/src/DotNext/Collections/Generic/Sequence.cs
@@ -146,10 +146,10 @@ public static partial class Sequence
         {
             case List<T> list:
                 var index = list.FindIndex(filter);
-                return index >= 0 ? list[0] : Optional<T>.None;
+                return index >= 0 ? list[index] : Optional<T>.None;
             case T[] array:
                 index = Array.FindIndex(array, filter);
-                return index >= 0 ? array[0] : Optional<T>.None;
+                return index >= 0 ? array[index] : Optional<T>.None;
             case LinkedList<T> list:
                 return FindInLinkedList(list, filter);
             default:


### PR DESCRIPTION
FirstOrEmpty() should be return the first item which is match the predicate, but this commit breaks this behavior:
[https://github.com/dotnet/dotNext/commit/589c1af7fe30732424750f807da3ff34a8f90e10](https://github.com/dotnet/dotNext/commit/589c1af7fe30732424750f807da3ff34a8f90e10)

> @sxul , thanks for the contribution! Could you please synchronize with `develop` branch and then change the base of this PR to `develop` branch instead of `master`.

Sorry, I have already create a new PR