### PR TITLE
Fix issue with loading persisted cluster configuration from disk when a cluster change occurred

### DIFF
--- a/src/DotNext.Tests/Net/Cluster/Consensus/Raft/Membership/ClusterConfigurationStorageTests.cs
+++ b/src/DotNext.Tests/Net/Cluster/Consensus/Raft/Membership/ClusterConfigurationStorageTests.cs
@@ -131,11 +131,22 @@ namespace DotNext.Net.Cluster.Consensus.Raft.Membership
                 await storage.ApplyAsync();
             }
 
+            var ep2 = new HttpEndPoint(new Uri("https://localhost:3263", UriKind.Absolute));
+            var id2 = ClusterMemberId.FromEndPoint(ep2);
+
+            await using (var storage = new PersistentClusterConfigurationStorage(path))
+            {
+                await storage.LoadConfigurationAsync();
+                True(await storage.AddMemberAsync(id2, ep2));
+                await storage.ApplyAsync();
+            }
+
             await using (var storage = new PersistentClusterConfigurationStorage(path))
             {
                 await storage.LoadConfigurationAsync();
                 Null(storage.As<IClusterConfigurationStorage<HttpEndPoint>>().ProposedConfiguration);
                 Equal(ep, storage.As<IClusterConfigurationStorage<HttpEndPoint>>().ActiveConfiguration[id]);
+                Equal(ep2, storage.As<IClusterConfigurationStorage<HttpEndPoint>>().ActiveConfiguration[id2]);
             }
         }
 

--- a/src/cluster/DotNext.Net.Cluster/Net/Cluster/Consensus/Raft/Membership/PersistentClusterConfigurationStorage.cs
+++ b/src/cluster/DotNext.Net.Cluster/Net/Cluster/Consensus/Raft/Membership/PersistentClusterConfigurationStorage.cs
@@ -64,6 +64,7 @@ public abstract class PersistentClusterConfigurationStorage<TAddress> : ClusterC
             output.fs.SetLength(Length);
             output.Fingerprint = Fingerprint;
             fs.Position = 0L;
+            output.fs.Position = 0L;
             await fs.CopyToAsync(output.fs, bufferSize, token).ConfigureAwait(false);
             await output.fs.FlushAsync(token).ConfigureAwait(false);
         }


### PR DESCRIPTION
Consider the following scenario:

Start a few RAFT nodes which are not clustered
Use AddMemberAsync to pair them and ApplyAsync to save it to disk
Kill the nodes and restart them, the configuration is lost.
Fix implemented in the write to the filestream.

Expanded applicable unit test.