### PR TITLE
Fix not initialized `index` field in `CommitChecker`

### DIFF
--- a/src/cluster/DotNext.Net.Cluster/Net/Cluster/Consensus/Raft/ConsensusOnlyState.cs
+++ b/src/cluster/DotNext.Net.Cluster/Net/Cluster/Consensus/Raft/ConsensusOnlyState.cs
@@ -85,6 +85,7 @@ public sealed class ConsensusOnlyState : Disposable, IPersistentState
             Debug.Assert(state is not null);
 
             this.state = state;
+            this.index = index;
         }
 
         bool ISupplier<bool>.Invoke()

--- a/src/cluster/DotNext.Net.Cluster/Net/Cluster/Consensus/Raft/PersistentState.NodeState.cs
+++ b/src/cluster/DotNext.Net.Cluster/Net/Cluster/Consensus/Raft/PersistentState.NodeState.cs
@@ -266,6 +266,7 @@ public partial class PersistentState
             Debug.Assert(state is not null);
 
             this.state = state;
+            this.index = index;
         }
 
         bool ISupplier<bool>.Invoke() => index <= state.CommitIndex;


### PR DESCRIPTION
While reading code I noticed "Parameter 'index' is never used" hint. It seems the two `index` fields should be initialized in constructors.