### PR TITLE
Fix DotNext.Reflection.TypeExtensions.IsUnmanaged

### DIFF
--- a/src/DotNext.Tests/Reflection/TypeExtensionsTests.cs
+++ b/src/DotNext.Tests/Reflection/TypeExtensionsTests.cs
@@ -58,8 +58,10 @@ public sealed class TypeExtensionsTests : Test
         True(typeof(bool).IsUnmanaged());
         True(typeof(Guid).IsUnmanaged());
         True(typeof(DateTime).IsUnmanaged());
-        False(typeof(Runtime.InteropServices.Pointer<int>).IsUnmanaged());
+        True(typeof((int, int)).IsUnmanaged());
+        True(typeof(Runtime.InteropServices.Pointer<int>).IsUnmanaged());
         False(typeof(ManagedStruct).IsUnmanaged());
+        False(typeof((int, string)).IsUnmanaged());
         var method = new Func<int>(SizeOf<long>).Method;
         method = method.GetGenericMethodDefinition();
         True(method.GetGenericArguments()[0].IsUnmanaged());

--- a/src/DotNext/Reflection/TypeExtensions.cs
+++ b/src/DotNext/Reflection/TypeExtensions.cs
@@ -30,7 +30,7 @@ public static class TypeExtensions
     {
         switch (type)
         {
-            case { IsGenericType: true } or { IsGenericTypeDefinition: true } or { IsGenericParameter: true }:
+            case { IsGenericTypeDefinition: true }:
                 foreach (var attribute in type.GetCustomAttributesData())
                 {
                     if (attribute.AttributeType.FullName == IsUnmanagedAttributeName)


### PR DESCRIPTION
This fixes the return value of the function, as right now it falsely returns `false` for generic types whose parameters are specified as unmanaged.

Minimal Reproducible Example:
```cs
typeof((int, int)).IsUnmanaged() // false, expected true
```
