### PR TITLE
Update Optional.cs

### DIFF
--- a/src/DotNext/Optional.cs
+++ b/src/DotNext/Optional.cs
@@ -116,7 +116,7 @@ public static class Optional
     public static Type? GetUnderlyingType(Type optionalType) => IsOptional(optionalType) ? optionalType.GetGenericArguments()[0] : null;
 
     /// <summary>
-    /// Constructs optional value from nullable reference type.
+    /// Constructs optional value from nullable value type.
     /// </summary>
     /// <typeparam name="T">Type of value.</typeparam>
     /// <param name="value">The value to convert.</param>


### PR DESCRIPTION
This pull request fixes an incorrect comment on the `ToOptional` method. The comment stated "Constructs optional value from nullable reference type", however the method is constrained with `where T : struct`, meaning it is explicitly designed to work with _nullable value types_ (`T?`) and cannot handle nullable reference types.