### PR TITLE
Added convenience methods for easier Monad creation and Monad chaining

### DIFF
--- a/src/DotNext/Optional.cs
+++ b/src/DotNext/Optional.cs
@@ -73,6 +73,14 @@ public static class Optional
         => await (await task.ConfigureAwait(false)).Convert(converter).ConfigureAwait(false);
 
     /// <summary>
+    /// Creates a new instance of <see cref="Optional{T}"/> from the specified value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <param name="value">The value to be placed to the container.</param>
+    /// <returns>The value encapsulated by <see cref="Result{T}"/>.</returns>
+    public static Optional<T> FromValue<T>(T value) => new(value);
+
+    /// <summary>
     /// Creates <see cref="Result{T}"/> from <see cref="Optional{T}"/> instance.
     /// </summary>
     /// <param name="optional">The optional value.</param>

--- a/src/DotNext/Optional.cs
+++ b/src/DotNext/Optional.cs
@@ -49,6 +49,69 @@ public static class Optional
         => (await task.ConfigureAwait(false)).Convert(converter);
 
     /// <summary>
+    /// If a value is present, apply the provided mapping function to it, and if the result is
+    /// non-null, return an Optional describing the result. Otherwise returns <see cref="Optional{T}.None"/>.
+    /// </summary>
+    /// <typeparam name="TInput">The type of stored in the Optional container.</typeparam>
+    /// <typeparam name="TOutput">The type of the result of the mapping function.</typeparam>
+    /// <param name="task">The task containing Optional value.</param>
+    /// <param name="converter">A mapping function to be applied to the value, if present.</param>
+    /// <returns>An Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise <see cref="Optional{T}.None"/>.</returns>
+    public static async Task<Optional<TOutput>> Convert<TInput, TOutput>(this Task<Optional<TInput>> task, Converter<TInput, Optional<TOutput>> converter)
+        => (await task.ConfigureAwait(false)).Convert(converter);
+
+    /// <summary>
+    /// If a value is present, apply the provided mapping function to it, and if the result is
+    /// non-null, return an Optional describing the result. Otherwise returns <see cref="Optional{T}.None"/>.
+    /// </summary>
+    /// <typeparam name="TInput">The type of stored in the Optional container.</typeparam>
+    /// <typeparam name="TOutput">The type of the result of the mapping function.</typeparam>
+    /// <param name="task">The task containing Optional value.</param>
+    /// <param name="converter">A mapping function to be applied to the value, if present.</param>
+    /// <returns>An Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise <see cref="Optional{T}.None"/>.</returns>
+    public static async Task<Optional<TOutput>> Convert<TInput, TOutput>(this Task<Optional<TInput>> task, Converter<TInput, Task<Optional<TOutput>>> converter)
+        => await (await task.ConfigureAwait(false)).Convert(converter).ConfigureAwait(false);
+
+    /// <summary>
+    /// Creates <see cref="Result{T}"/> from <see cref="Optional{T}"/> instance.
+    /// </summary>
+    /// <param name="optional">The optional value.</param>
+    /// <returns>The converted optional value.</returns>
+    public static Result<T> ToResult<T>(this in Optional<T> optional)
+        => Result<T>.FromOptional(optional);
+
+    /// <summary>
+    /// Creates <see cref="Result{T}"/> from <see cref="Optional{T}"/> instance.
+    /// </summary>
+    /// <param name="task">The task containing Optional value.</param>
+    /// <returns>The converted optional value.</returns>
+    public static async Task<Result<T>> ToResult<T>(this Task<Optional<T>> task)
+        => Result<T>.FromOptional(await task.ConfigureAwait(false));
+
+    /// <summary>
+    /// Creates <see cref="Result{T, TError}"/> from <see cref="Optional{T}"/> instance.
+    /// </summary>
+    /// <param name="optional">The optional value.</param>
+    /// <param name="error">The error code to apply if the value is not present.</param>
+    /// <returns>The converted optional value.</returns>
+    public static Result<T, TError> ToResult<T, TError>(this in Optional<T> optional, TError error)
+        where TError : struct, Enum
+        => optional.HasValue ? new(optional.Value) : new(error);
+
+    /// <summary>
+    /// Creates <see cref="Result{T, TError}"/> from <see cref="Optional{T}"/> instance.
+    /// </summary>
+    /// <param name="task">The task containing Optional value.</param>
+    /// <param name="error">The error code to apply if the value is not present.</param>
+    /// <returns>The converted optional value.</returns>
+    public static async Task<Result<T, TError>> ToResult<T, TError>(this Task<Optional<T>> task, TError error)
+        where TError : struct, Enum
+    {
+        var optional = await task.ConfigureAwait(false);
+        return optional.HasValue ? new(optional.Value) : new(error);
+    }
+
+    /// <summary>
     /// If a value is present, returns the value, otherwise throw exception.
     /// </summary>
     /// <param name="task">The task returning optional value.</param>
@@ -553,6 +616,11 @@ public readonly struct Optional<T> : IEquatable<Optional<T>>, IEquatable<T>, ISt
         where TConverter : struct, ISupplier<T, Optional<TResult>>
         => HasValue ? converter.Invoke(value) : Optional<TResult>.None;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Task<Optional<TResult>> ConvertOptionalTask<TResult, TConverter>(TConverter converter)
+        where TConverter : struct, ISupplier<T, Task<Optional<TResult>>>
+        => HasValue ? converter.Invoke(value) : Task.FromResult(Optional<TResult>.None);
+
     /// <summary>
     /// If a value is present, apply the provided mapping function to it, and if the result is
     /// non-null, return an Optional describing the result. Otherwise returns <see cref="None"/>.
@@ -570,9 +638,30 @@ public readonly struct Optional<T> : IEquatable<Optional<T>>, IEquatable<T>, ISt
     /// <typeparam name="TResult">The type of the result of the mapping function.</typeparam>
     /// <param name="mapper">A mapping function to be applied to the value, if present.</param>
     /// <returns>An Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise <see cref="None"/>.</returns>
+    public Task<Optional<TResult>> Convert<TResult>(Converter<T, Task<Optional<TResult>>> mapper)
+        => ConvertOptionalTask<TResult, DelegatingConverter<T, Task<Optional<TResult>>>>(mapper);
+
+    /// <summary>
+    /// If a value is present, apply the provided mapping function to it, and if the result is
+    /// non-null, return an Optional describing the result. Otherwise returns <see cref="None"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result of the mapping function.</typeparam>
+    /// <param name="mapper">A mapping function to be applied to the value, if present.</param>
+    /// <returns>An Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise <see cref="None"/>.</returns>
     [CLSCompliant(false)]
     public unsafe Optional<TResult> Convert<TResult>(delegate*<T, Optional<TResult>> mapper)
         => ConvertOptional<TResult, Supplier<T, Optional<TResult>>>(mapper);
+
+    /// <summary>
+    /// If a value is present, apply the provided mapping function to it, and if the result is
+    /// non-null, return an Optional describing the result. Otherwise returns <see cref="None"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result of the mapping function.</typeparam>
+    /// <param name="mapper">A mapping function to be applied to the value, if present.</param>
+    /// <returns>An Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise <see cref="None"/>.</returns>
+    [CLSCompliant(false)]
+    public unsafe Task<Optional<TResult>> Convert<TResult>(delegate*<T, Task<Optional<TResult>>> mapper)
+        => ConvertOptionalTask<TResult, Supplier<T, Task<Optional<TResult>>>>(mapper);
 
     /// <inheritdoc cref="IFunctional{TDelegate}.ToDelegate()"/>
     Func<object?> IFunctional<Func<object?>>.ToDelegate() => Func.Constant<object?>(kind is NotEmptyValue ? value : null);

--- a/src/DotNext/Result.cs
+++ b/src/DotNext/Result.cs
@@ -69,12 +69,34 @@ public static class Result
     public static Result<T> FromValue<T>(T value) => new(value);
 
     /// <summary>
+    /// Creates a new instance of <see cref="Result{T}"/> from the specified value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <typeparam name="TError">The type of the error code. Default value must represent the successful result.</typeparam>
+    /// <param name="value">The value to be placed to the container.</param>
+    /// <returns>The value encapsulated by <see cref="Result{T, TError}"/>.</returns>
+    public static Result<T, TError> FromValue<T, TError>(T value)
+        where TError: struct, Enum
+        => new(value);
+
+    /// <summary>
     /// Creates a new instance of <see cref="Result{T}"/> from the specified exception.
     /// </summary>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <param name="e">The exception to be placed to the container.</param>
     /// <returns>The exception encapsulated by <see cref="Result{T}"/>.</returns>
     public static Result<T> FromException<T>(Exception e) => new(e);
+
+    /// <summary>
+    /// Creates a new instance of <see cref="Result{T, TError}"/> from the specified exception.
+    /// </summary>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <typeparam name="TError">The type of the error code. Default value must represent the successful result.</typeparam>
+    /// <param name="e">The error to be placed to the container.</param>
+    /// <returns>The exception encapsulated by <see cref="Result{T}"/>.</returns>
+    public static Result<T, TError> FromError<T, TError>(TError e)
+        where TError: struct, Enum
+        => new(e);
 
     /// <summary>
     /// If successful result is present, apply the provided mapping function hiding any exception


### PR DESCRIPTION
I added some convenience methods to the library. The Option class receives a few extension methods that allow for chaining async conversions:

```
var optional = await Optional.FromValue(42)
    .Convert(async x => x > 10 ? Optional.FromValue(x * 2.0 - 20) : Optional<double>.None)
    .Convert(async x => x > 0 ? Optional.FromValue("Success") : Optional<string>.None);

Console.WriteLine(optional.HasValue ? optional.Value : "Optional has no value");
```

This is really useful if you work with databases where data is fetched / transformed multiple times asynchronously before being filled into a DTO.
The same thing for Result:

```
var result = await Result.FromValue(42)
    .Convert(async x => x > 10 ? Result.FromValue(x * 2.0 - 20) : Result.FromException<double>(new Exception("x too small")))
    .Convert(async x => x > 0 ? Result.FromValue("Success") : Result.FromException<string>(new Exception("x less than zero")));

Console.WriteLine(result.IsSuccessful ? result : $"Failed with exception: {result.Error}");
```

This also forwards the exception up the chain just like with regular monads.
Also, I added some additional convenience methods for creating Options and Results statically:

```
var optionalWithValue = Optional.FromValue(42);
var errorCodeResultWithValue = Result.FromValue<int, TestError>(42);
var errorCodeResultWithError = Result.FromError<int, TestError>(TestError.Error1);
```