### PR TITLE
Add ! operator overloading for the result types.

### DIFF
--- a/src/DotNext.Tests/ResultTests.cs
+++ b/src/DotNext.Tests/ResultTests.cs
@@ -72,12 +72,16 @@ public sealed class ResultTests : Test
         var result = new Result<int>(10);
         if (result) { }
         else Fail("Unexpected Result state");
+        if (!result) Fail("Unexpected Result state");
         Equal(10, (int)result);
         Equal("10", result.ToString());
         Optional<int> opt = result;
         Equal(10, opt);
         Equal(10, result.OrInvoke(static () => 20));
         result = new Result<int>(new Exception());
+        if (result) Fail("Unexpected Result state");
+        if (!result) { }
+        else Fail("Unexpected Result state");
         Equal(20, result.OrInvoke(static () => 20));
         opt = result;
         False(opt.HasValue);
@@ -89,12 +93,16 @@ public sealed class ResultTests : Test
         var result = new Result<int, EnvironmentVariableTarget>(10);
         if (result) { }
         else Fail("Unexpected Result state");
+        if (!result) Fail("Unexpected Result state");
         Equal(10, (int)result);
         Equal("10", result.ToString());
         Optional<int> opt = result;
         Equal(10, opt);
         Equal(10, result.OrInvoke(static () => 20));
         result = new Result<int, EnvironmentVariableTarget>(EnvironmentVariableTarget.Machine);
+        if (result) Fail("Unexpected Result state");
+        if (!result) { }
+        else Fail("Unexpected Result state");
         Equal(20, result.OrInvoke(static () => 20));
         opt = result;
         False(opt.HasValue);

--- a/src/DotNext/Result.cs
+++ b/src/DotNext/Result.cs
@@ -377,6 +377,13 @@ public readonly struct Result<T> : IResultMonad<T, Exception, Result<T>>
     public static bool operator &(in Result<T> left, in Result<T> right) => left.exception is null && right.exception is null;
 
     /// <summary>
+    /// Indicates that the result represents error.
+    /// </summary>
+    /// <param name="result">The result to check.</param>
+    /// <returns><see langword="false"/> if this result is successful; <see langword="true"/> if this result represents exception.</returns>
+    public static bool operator !(in Result<T> result) => result.exception is not null;
+
+    /// <summary>
     /// Indicates that the result is successful.
     /// </summary>
     /// <param name="result">The result to check.</param>
@@ -698,6 +705,13 @@ public readonly struct Result<T, TError> : IResultMonad<T, TError, Result<T, TEr
     /// <param name="right">The second result to check.</param>
     /// <returns><see langword="true"/> if both results are successful; otherwise, <see langword="false"/>.</returns>
     public static bool operator &(in Result<T, TError> left, in Result<T, TError> right) => left.IsSuccessful && right.IsSuccessful;
+
+    /// <summary>
+    /// Indicates that the result represents error.
+    /// </summary>
+    /// <param name="result">The result to check.</param>
+    /// <returns><see langword="false"/> if this result is successful; <see langword="true"/> if this result represents exception.</returns>
+    public static bool operator !(in Result<T, TError> result) => !result.IsSuccessful;
 
     /// <summary>
     /// Indicates that the result is successful.


### PR DESCRIPTION
Currently the result type supports `if (result) { }`. https://dotnet.github.io/dotNext/features/core/result.html

However, `if (!result) { }` does not work.

Add the `!` operator overloading for `Result<T>` and `Result<T, TError>` to support `if (!result) { }`.