### PR TITLE
Add optional maximum capacity to buffer writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Release Notes
 ====
 
+# 07-08-2026
+<a href="https://www.nuget.org/packages/dotnext/6.4.0">DotNext 6.4.0</a>
+* Added optional `MaxCapacity` to `PoolingBufferWriter<T>`, `PoolingArrayBufferWriter<T>`, and `BufferWriterSlim<T>` that bounds the growth of the internal buffer
+
 # 06-30-2026
 <a href="https://www.nuget.org/packages/dotnext.net.cluster/6.4.0">DotNext.Net.Cluster 6.4.0</a>
 * Fixed potential [NullReferenceException](https://learn.microsoft.com/en-us/dotnet/api/system.nullreferenceexception) in `WriteAheadLog` constructor

--- a/src/DotNext.Tests/Buffers/BufferWriterSlimTests.cs
+++ b/src/DotNext.Tests/Buffers/BufferWriterSlimTests.cs
@@ -329,6 +329,68 @@ public sealed class BufferWriterSlimTests : Test
     }
 
     [Fact]
+    public static void UnboundedMaxCapacityByDefault()
+    {
+        var buffer = new BufferWriterSlim<int>(stackalloc int[3]);
+        Equal(int.MaxValue, buffer.MaxCapacity);
+    }
+
+    [Fact]
+    public static void MaxCapacityValidation()
+    {
+        var raised = false;
+        try
+        {
+            _ = new BufferWriterSlim<int>(stackalloc int[3]) { MaxCapacity = 0 };
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            raised = true;
+        }
+
+        True(raised);
+    }
+
+    [Fact]
+    public static void GrowWithinMaxCapacity()
+    {
+        var buffer = new BufferWriterSlim<int>(stackalloc int[2]) { MaxCapacity = 4 };
+        try
+        {
+            Equal(4, buffer.MaxCapacity);
+
+            buffer.Write([1, 2, 3, 4]);
+            Equal(4, buffer.WrittenCount);
+            True(buffer.Capacity >= 4);
+        }
+        finally
+        {
+            buffer.Dispose();
+        }
+    }
+
+    [Fact]
+    public static void GrowBeyondMaxCapacity()
+    {
+        var buffer = new BufferWriterSlim<int>(stackalloc int[2]) { MaxCapacity = 4 };
+        var raised = false;
+        try
+        {
+            buffer.Write([1, 2, 3, 4, 5]);
+        }
+        catch (InsufficientMemoryException)
+        {
+            raised = true;
+        }
+        finally
+        {
+            buffer.Dispose();
+        }
+
+        True(raised);
+    }
+
+    [Fact]
     public static void EncodeAsUtf8()
     {
         var writer = new BufferWriterSlim<byte>();

--- a/src/DotNext.Tests/Buffers/BufferWriterTests.cs
+++ b/src/DotNext.Tests/Buffers/BufferWriterTests.cs
@@ -208,6 +208,70 @@ public sealed class BufferWriterTests : Test
         }
     }
 
+    public static TheoryData<BufferWriter<byte>> BoundedBuffers() =>
+    [
+        new PoolingBufferWriter<byte> { MaxCapacity = 16 },
+        new PoolingArrayBufferWriter<byte> { MaxCapacity = 16 },
+    ];
+
+    [Theory]
+    [MemberData(nameof(BoundedBuffers))]
+    public static void GrowWithinMaxCapacity(BufferWriter<byte> writer)
+    {
+        using (writer)
+        {
+            Equal(16, writer.MaxCapacity);
+
+            writer.Write(new byte[16]);
+            Equal(16, writer.WrittenCount);
+            True(writer.Capacity >= 16);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(BoundedBuffers))]
+    public static void GrowBeyondMaxCapacity(BufferWriter<byte> writer)
+    {
+        using (writer)
+            Throws<InsufficientMemoryException>(() => writer.Write(new byte[17]));
+    }
+
+    [Fact]
+    public static void GrowClampedToMaxCapacity()
+    {
+        // ArrayPool<byte>.Shared.Rent(16) returns an array of exactly 16 elements,
+        // so the internal capacity is observable here.
+        using var writer = new PoolingArrayBufferWriter<byte> { MaxCapacity = 16 };
+
+        // Without a limit, the first write would grow the buffer to the default
+        // initial size (128). Because the write exactly matches MaxCapacity, growth
+        // is clamped to 16 instead, and the write still succeeds.
+        writer.Write(new byte[16]);
+        Equal(16, writer.WrittenCount);
+        Equal(16, writer.Capacity);
+        Equal(0, writer.FreeCapacity);
+
+        // The buffer sits exactly at MaxCapacity, so any further growth must throw.
+        Throws<InsufficientMemoryException>(() => writer.Add(0));
+    }
+
+    [Fact]
+    public static void MaxCapacityValidation()
+    {
+        Throws<ArgumentOutOfRangeException>(static () => new PoolingBufferWriter<byte> { MaxCapacity = 0 });
+        Throws<ArgumentOutOfRangeException>(static () => new PoolingArrayBufferWriter<byte> { MaxCapacity = -1 });
+    }
+
+    [Fact]
+    public static void UnboundedMaxCapacityByDefault()
+    {
+        using var writer1 = new PoolingBufferWriter<byte>();
+        Equal(int.MaxValue, writer1.MaxCapacity);
+
+        using var writer2 = new PoolingArrayBufferWriter<byte>();
+        Equal(int.MaxValue, writer2.MaxCapacity);
+    }
+
     [Fact]
     public static void Concatenation()
     {

--- a/src/DotNext/Buffers/BufferWriter.cs
+++ b/src/DotNext/Buffers/BufferWriter.cs
@@ -27,6 +27,8 @@ public abstract class BufferWriter<T> : Disposable, ISupplier<ReadOnlyMemory<T>>
     /// </summary>
     private protected int position;
 
+    private int maxCapacity = int.MaxValue;
+
     /// <summary>
     /// Initializes a new memory writer.
     /// </summary>
@@ -202,6 +204,31 @@ public abstract class BufferWriter<T> : Disposable, ISupplier<ReadOnlyMemory<T>>
     public abstract int Capacity { get; init; }
 
     /// <summary>
+    /// Gets or sets the maximum amount of space that the underlying memory is allowed to grow to.
+    /// </summary>
+    /// <remarks>
+    /// The limit is checked when the writer needs to grow the internal buffer to satisfy a write request.
+    /// If the requested size exceeds this value, <see cref="InsufficientMemoryException"/> is thrown.
+    /// By default, the maximum capacity is unbounded.
+    /// <para/>
+    /// This value bounds the growth request rather than the exact size of the underlying buffer. Because
+    /// the buffer is rented from a memory pool, the allocator may round the request up to the next bucket,
+    /// so the actual <see cref="Capacity"/> can be somewhat larger than this value. The overshoot is
+    /// determined by the pool's bucket sizes and stays reasonably bounded.
+    /// </remarks>
+    /// <value>The maximum capacity of the internal buffer.</value>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is less than or equal to zero.</exception>
+    public int MaxCapacity
+    {
+        get => maxCapacity;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+            maxCapacity = value;
+        }
+    }
+
+    /// <summary>
     /// Gets the amount of space available that can still be written into without forcing the underlying buffer to grow.
     /// </summary>
     public int FreeCapacity => Capacity - WrittenCount;
@@ -284,7 +311,7 @@ public abstract class BufferWriter<T> : Disposable, ISupplier<ReadOnlyMemory<T>>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private protected void CheckAndResizeBuffer(int sizeHint)
     {
-        if (IGrowableBuffer<T>.GetBufferSize(sizeHint, Capacity, position, out sizeHint))
+        if (IGrowableBuffer<T>.GetBufferSize(sizeHint, Capacity, position, maxCapacity, out sizeHint))
             Resize(sizeHint);
     }
 

--- a/src/DotNext/Buffers/BufferWriterSlim.cs
+++ b/src/DotNext/Buffers/BufferWriterSlim.cs
@@ -30,7 +30,7 @@ public ref partial struct BufferWriterSlim<T> : IGrowableBuffer<T>
     private readonly MemoryAllocator<T> allocator;
     private MemoryOwner<T> extraBuffer;
     private int position;
-
+    private int maxCapacity;
     /// <summary>
     /// Initializes growable buffer.
     /// </summary>
@@ -98,6 +98,31 @@ public ref partial struct BufferWriterSlim<T> : IGrowableBuffer<T>
     public readonly int Capacity => extraBuffer.IsEmpty ? initialBuffer.Length : extraBuffer.Length;
 
     /// <summary>
+    /// Gets or sets the maximum amount of space that the underlying memory is allowed to grow to.
+    /// </summary>
+    /// <remarks>
+    /// The limit is checked when the builder needs to grow the internal buffer to satisfy a write request.
+    /// If the requested size exceeds this value, <see cref="InsufficientMemoryException"/> is thrown.
+    /// By default, the maximum capacity is unbounded.
+    /// <para/>
+    /// This value bounds the growth request rather than the exact size of the underlying buffer. Because
+    /// the extra buffer is rented from a memory pool, the allocator may round the request up to the next
+    /// bucket, so the actual <see cref="Capacity"/> can be somewhat larger than this value. The overshoot is
+    /// determined by the pool's bucket sizes and stays reasonably bounded.
+    /// </remarks>
+    /// <value>The maximum capacity of the internal buffer.</value>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is less than or equal to zero.</exception>
+    public int MaxCapacity
+    {
+        readonly get => maxCapacity is 0 ? int.MaxValue : maxCapacity;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+            maxCapacity = value;
+        }
+    }
+
+    /// <summary>
     /// Gets the amount of space available that can still be written into without forcing the underlying buffer to grow.
     /// </summary>
     public readonly int FreeCapacity => Capacity - WrittenCount;
@@ -139,7 +164,7 @@ public ref partial struct BufferWriterSlim<T> : IGrowableBuffer<T>
         else
         {
             // copy everything to the extra buffer, because it's not possible to return the stack pointer
-            IGrowableBuffer<T>.GetBufferSize(sizeHint, initialBuffer.Length, position, out var newSize);
+            IGrowableBuffer<T>.GetBufferSize(sizeHint, initialBuffer.Length, position, MaxCapacity, out var newSize);
             extraBuffer = allocator.AllocateAtLeast(newSize);
             initialBuffer.Slice(0, position).CopyTo(extraBuffer.Span);
         }
@@ -158,7 +183,7 @@ public ref partial struct BufferWriterSlim<T> : IGrowableBuffer<T>
             EnsureExtraBufferSize(sizeHint);
             result = extraBuffer.Span;
         }
-        else if (IGrowableBuffer<T>.GetBufferSize(sizeHint, initialBuffer.Length, position, out var newSize))
+        else if (IGrowableBuffer<T>.GetBufferSize(sizeHint, initialBuffer.Length, position, MaxCapacity, out var newSize))
         {
             extraBuffer = allocator.AllocateAtLeast(newSize);
             initialBuffer.CopyTo(result = extraBuffer.Span);
@@ -173,7 +198,7 @@ public ref partial struct BufferWriterSlim<T> : IGrowableBuffer<T>
 
     private void EnsureExtraBufferSize(int sizeHint)
     {
-        if (IGrowableBuffer<T>.GetBufferSize(sizeHint, extraBuffer.Length, position, out sizeHint))
+        if (IGrowableBuffer<T>.GetBufferSize(sizeHint, extraBuffer.Length, position, MaxCapacity, out sizeHint))
             extraBuffer.Resize(sizeHint, allocator);
     }
 

--- a/src/DotNext/Buffers/IGrowableBuffer.cs
+++ b/src/DotNext/Buffers/IGrowableBuffer.cs
@@ -138,10 +138,14 @@ public interface IGrowableBuffer<T> :
     bool TryGetWrittenContent(out ReadOnlyMemory<T> block);
 
     private protected static bool GetBufferSize(int sizeHint, int capacity, int writtenCount, out int newSize)
+        => GetBufferSize(sizeHint, capacity, writtenCount, int.MaxValue, out newSize);
+
+    private protected static bool GetBufferSize(int sizeHint, int capacity, int writtenCount, int maxCapacity, out int newSize)
     {
         Debug.Assert(sizeHint >= 0);
         Debug.Assert(capacity >= 0);
         Debug.Assert(writtenCount >= 0);
+        Debug.Assert(maxCapacity > 0);
 
         if (sizeHint is 0)
             sizeHint = 1;
@@ -151,6 +155,14 @@ public interface IGrowableBuffer<T> :
             var growBy = capacity is 0 ? DefaultInitialBufferSize : capacity;
             if ((sizeHint > growBy || (uint)(growBy += capacity) > (uint)Array.MaxLength) && (uint)(growBy = capacity + sizeHint) > (uint)Array.MaxLength)
                 throw new InsufficientMemoryException();
+
+            if (growBy > maxCapacity)
+            {
+                if (sizeHint > maxCapacity - writtenCount)
+                    throw new InsufficientMemoryException();
+
+                growBy = maxCapacity;
+            }
 
             newSize = growBy;
             return true;


### PR DESCRIPTION
## Motivation

Frequently you want to buffer but want to be sure it won't each unnecessary too much memory, have some (even if high) upper ceiling. This PR implements in the less impactful way. It's not limit for writing, it's a limit for sizing the buffer. 

Not a strict one (as pool can give you bigger) but somewhat guaranteeing you won't OOM. Implemented this way it has almost no perf impact and doesn't complicate the usage much.

If desired it can be tightened up to either strictly limite the buffer / writes (so that it's guaranteed not to get bigger capacity buffer; thus also write more). I don't think it's needed (not for my usecase at least) but could be useful for some. 

## Summary
Adds an optional `MaxCapacity` limit to the pooling buffer writers so buffer growth can be bounded.

`MaxCapacity` is now available on:
- `PoolingBufferWriter<T>` and `PoolingArrayBufferWriter<T>` (via the shared `BufferWriter<T>` base class)
- `BufferWriterSlim<T>`

When a write requires the internal buffer to grow beyond `MaxCapacity`, `InsufficientMemoryException` is thrown — consistent with the existing `Array.MaxLength` ceiling and the other max-size guards across the library. The check lives in the shared grow path (`IGrowableBuffer<T>.GetBufferSize`); when the write still fits, the growth request is clamped to `MaxCapacity`. By default the maximum capacity is unbounded.

## Notes
- The value bounds the growth *request*, not the exact physical buffer size: because buffers are rented from a pool, the allocator may round up to the next bucket, so the actual `Capacity` can be slightly larger. This is documented in the API remarks.
- `SparseBufferWriter<T>` is intentionally not affected — it grows by appending independent chunks and does not use the shared grow path.

## Tests
Added unit tests covering growth within the limit, growth beyond the limit (throws), exact-boundary clamping, validation of invalid values, and the unbounded default.
