### PR TITLE
Make the AI model contribution note sound more natural

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,4 +25,4 @@ Contributions must not contain breaking changes such as backward incompatible mo
 If your PR contains bug fix or new feature then it should have unit tests.
 
 ## AI
-If your PR was fully or partially made by the AI model (Codex, Claude, etc.), add `ai_assisted` label to it.
+If your PR was fully or partially made by an AI model (Codex, Claude, etc.), add the `ai_assisted` label to it.


### PR DESCRIPTION
This PR fixes a minor wording issue in CONTRIBUTING.md: it clarifies the sentence about AI-assisted contributions by adding the missing articles.